### PR TITLE
Clear contents of docs/ before regenerating

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [Homebrew RubyDoc](https://rubydoc.brew.sh) is an online Ruby documentation browser for [Homebrew/brew](https://github.com/Homebrew/brew).
 
-A [GitHub Action in Homebrew/brew](https://github.com/Homebrew/brew/blob/master/.github/main.workflow) is run on each commit, which deploys the site to GitHub Pages.
+A [GitHub Action in Homebrew/brew](https://github.com/Homebrew/brew/blob/master/.github/workflows/apidoc.yml) is run on each commit, which deploys the site to GitHub Pages.
 
 ## Usage
 
@@ -14,7 +14,7 @@ To instead run Homebrew RubyDoc locally, run:
 git clone https://github.com/Homebrew/rubydoc.brew.sh
 cd rubydoc.brew.sh
 bundle install
-bundle exec jekyll serve
+bundle exec jekyll serve --source docs
 ```
 
 ## License

--- a/Rakefile
+++ b/Rakefile
@@ -5,6 +5,7 @@ task default: :yard
 
 desc "Generate documentation with YARD"
 task :yard do
+  sh "find", "docs", "-mindepth", "1", "!", "-name", "_config.yml", "!", "-name", "CNAME", "-delete"
   sh "bundle", "exec", "yard"
 end
 


### PR DESCRIPTION
Currently, classes that have since been removed or combined (like [MaximumMacOSRequirement](https://rubydoc.brew.sh/MaximumMacOSRequirement.html)) still appear in the API docs. This has the default `rake` task clear all but the `_config.yml` and `CNAME` files from `docs/` beforehand to remove any such stale files.

Also includes fixes for the README, one of which depends on Homebrew/brew#6418.

(cc @MikeMcQuaid)