### PR TITLE
workflows/tests: clone Homebrew/brew before building

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,4 +21,6 @@ jobs:
         bundle install --jobs 4 --retry 3
 
     - name: Generate site
-      run: bundle exec rake yard build
+      run: |
+        git clone --depth=1 https://github.com/Homebrew/brew
+        bundle exec rake yard build


### PR DESCRIPTION
CI was passing because there was [nothing being built](https://github.com/Homebrew/rubydoc.brew.sh/runs/213231002#step:5:1).

(cc @MikeMcQuaid)