### PR TITLE
GitHub Actions (more) cleanup

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -38,11 +38,12 @@ jobs:
 
     - name: Generate site
       run: |
-        git checkout -b master
-
         ln -s $(brew --repo) brew
         bundle exec rake yard build
 
+    - name: Commit changes
+      run: |
+        git reset origin/master
         if ! git diff --no-patch --exit-code HEAD -- docs; then
           git add docs
           git commit -m "docs: updates from Homebrew/brew" docs

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,6 +10,10 @@ jobs:
     - name: Set up Git repository
       uses: actions/checkout@main
 
+    - name: Set up Homebrew
+      id: set-up-homebrew
+      uses: Homebrew/actions/setup-homebrew@master
+
     - name: Set up Ruby
       uses: actions/setup-ruby@main
       with:
@@ -22,5 +26,5 @@ jobs:
 
     - name: Generate site
       run: |
-        git clone --depth=1 https://github.com/Homebrew/brew
+        ln -s $(brew --repo) brew
         bundle exec rake yard build


### PR DESCRIPTION
- reset to `origin/master` to avoid pushing changes we're testing on the `scheduled.yml` job
- more closely match `tests.yml` and `scheduled.yml`