### PR TITLE
Avoid generating incorrect module/class overviews

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -1,4 +1,5 @@
 --title "Homebrew Ruby API"
+--load ignore_directives.rb
 --markup markdown
 --no-private
 --output docs
@@ -7,6 +8,7 @@
 --exclude brew/Library/Homebrew/test/
 --exclude brew/Library/Homebrew/vendor/
 --exclude brew/Library/Homebrew/compat/
+brew/Library/Homebrew/extend/**/*.rb
 brew/Library/Homebrew/**/*.rb
 -
 brew/*.md

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [Homebrew RubyDoc](https://rubydoc.brew.sh) is an online Ruby documentation browser for [Homebrew/brew](https://github.com/Homebrew/brew).
 
-A [GitHub Action in Homebrew/brew](https://github.com/Homebrew/brew/blob/master/.github/workflows/apidoc.yml) is run on each commit, which deploys the site to GitHub Pages.
+A [GitHub Action](https://github.com/Homebrew/rubydoc.brew.sh/blob/master/.github/workflows/scheduled.yml) is run periodically, which deploys the site to GitHub Pages.
 
 ## Usage
 

--- a/ignore_directives.rb
+++ b/ignore_directives.rb
@@ -1,0 +1,9 @@
+# from https://github.com/lsegal/yard/issues/484#issuecomment-442586899
+class IgnoreDirectiveDocstringParser < YARD::DocstringParser
+  def parse_content(content)
+    return '' if !content || content.empty?
+    super(content.sub(/\Atyped:.*/m, ''))
+  end
+end
+
+YARD::Docstring.default_parser = IgnoreDirectiveDocstringParser


### PR DESCRIPTION
Several items at https://rubydoc.brew.sh/ are missing their Overview section (e.g. [Formula](https://rubydoc.brew.sh/Formula.html); compare with an earlier version at [rubydoc.info](https://rubydoc.info/github/Homebrew/brew/Formula)) because the comments above the class extension in `extend/os/mac/formula.rb` or `extend/os/mac/formula.rb` are overwriting it. This is fixed by [reading the files in `extend/` first](https://stackoverflow.com/a/10344776). This also fixes private classes appearing that should be omitted from in the output, e.g. DevelopmentTools.

Other cases where the Overview is set to `typed: false\n frozen_string_literal: true` were resolved by using a [custom parser](https://github.com/lsegal/yard/issues/484#issuecomment-442586899) to remove the directives beforehand.

cc @MikeMcQuaid 