### PR TITLE
Refinements for ignored directives

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -8,7 +8,7 @@
 --exclude brew/Library/Homebrew/test/
 --exclude brew/Library/Homebrew/vendor/
 --exclude brew/Library/Homebrew/compat/
-brew/Library/Homebrew/extend/**/*.rb
+brew/Library/Homebrew/extend/os/**/*.rb
 brew/Library/Homebrew/**/*.rb
 -
 brew/*.md

--- a/ignore_directives.rb
+++ b/ignore_directives.rb
@@ -2,7 +2,7 @@
 class IgnoreDirectiveDocstringParser < YARD::DocstringParser
   def parse_content(content)
     return '' if !content || content.empty?
-    super(content.sub(/\Atyped:.*/m, ''))
+    super(content.sub(/(\A(typed|.*rubocop)|TODO):.*/m, ''))
   end
 end
 


### PR DESCRIPTION
Drop any comments that start with `typed:` or contain [`rubocop:`](https://rubydoc.brew.sh/Utils/Inreplace.html), and trim any comments containing `TODO:`.

cc @MikeMcQuaid