### PR TITLE
Use Sorbet type annotations for documentation.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source "https://rubygems.org"
 
 gem "github-pages", group: :jekyll_plugins
 gem "yard"
+gem "yard-sorbet"
 
 group :test do
   gem "rake"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -239,6 +239,7 @@ GEM
       faraday (> 0.8, < 2.0)
     simpleidn (0.1.1)
       unf (~> 0.1.4)
+    sorbet-runtime (0.5.6084)
     terminal-table (1.8.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
     thread_safe (0.3.6)
@@ -251,6 +252,9 @@ GEM
     unf_ext (0.0.7.7)
     unicode-display_width (1.7.0)
     yard (0.9.25)
+    yard-sorbet (0.0.1)
+      sorbet-runtime (~> 0.5)
+      yard (~> 0.9)
     zeitwerk (2.4.1)
 
 PLATFORMS
@@ -260,6 +264,7 @@ DEPENDENCIES
   github-pages
   rake
   yard
+  yard-sorbet
 
 BUNDLED WITH
-   1.17.2
+   1.17.3

--- a/Rakefile
+++ b/Rakefile
@@ -6,7 +6,7 @@ task default: :yard
 desc "Generate documentation with YARD"
 task :yard do
   sh "find", "docs", "-mindepth", "1", "!", "-name", "_config.yml", "!", "-name", "CNAME", "-delete"
-  sh "bundle", "exec", "yard"
+  sh "bundle", "exec", "yard", "doc", "--plugin", "sorbet"
 end
 
 desc "Build the site"


### PR DESCRIPTION
This will reduce duplication between the documentation and the type signatures, as we'll no longer need to add types to `@param` and `@return` for documented functions. For functions currently without documentation, this will at least add return types and such for functions that have been annotated with type signatures.