### PR TITLE
Bump ruby version used in GH Actions

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up Ruby
         uses: actions/setup-ruby@main
         with:
-          ruby-version: "2.6"
+          ruby-version: "2.7"
 
       - name: Install RubyGems
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Ruby
         uses: actions/setup-ruby@main
         with:
-          ruby-version: "2.6"
+          ruby-version: "2.7"
 
       - name: Install RubyGems
         run: |


### PR DESCRIPTION
Ruby 2.6 has reached EOL and the next release of `yard-sorbet` requires ruby >= 2.7.

(I tested that `bundle exec rake yard build` succeeds, lmk if there's anything else required)