### PR TITLE
workflows: try use Ruby 3.1

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Set up Git repository
-        uses: actions/checkout@main
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
@@ -33,12 +33,8 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "2.7"
-
-      - name: Install RubyGems
-        run: |
-          gem install bundler -v "~>1"
-          bundle install --jobs 4 --retry 3
+          ruby-version: "3.1"
+          bundler-cache: true
 
       - name: Configure Git user
         uses: Homebrew/actions/git-user-config@master

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Set up Git repository
-        uses: actions/checkout@main
+        uses: actions/checkout@v4
 
       - name: Set up Homebrew
         id: set-up-homebrew
@@ -23,12 +23,8 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "2.7"
-
-      - name: Install RubyGems
-        run: |
-          gem install bundler -v "~>1"
-          bundle install --jobs 4 --retry 3
+          ruby-version: "3.1"
+          bundler-cache: true
 
       - name: Generate site
         run: |


### PR DESCRIPTION
Starting with rubydoc.brew.sh.

`github-pages` gem support status is a little unclear now that Actions-based deploys are a thing. It does not support Ruby 3.2 and 3.x support in general is unclear. I think 3.1 might be ok?

Will need to be at least 3.1 as it will be parsing Homebrew/brew code, which will eventually be targetting a minimum of Ruby 3.1.