### PR TITLE
Add `redcarpet` gem for Markdown support.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source "https://rubygems.org"
 gem "github-pages", group: :jekyll_plugins
 gem "yard"
 gem "yard-sorbet"
+gem "redcarpet"
 
 group :test do
   gem "rake"

--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,9 @@
 source "https://rubygems.org"
 
 gem "github-pages", group: :jekyll_plugins
+gem "redcarpet"
 gem "yard"
 gem "yard-sorbet"
-gem "redcarpet"
 
 group :test do
   gem "rake"


### PR DESCRIPTION
We use `--markup markdown` but don't have `redcarpet` specified as a dependency, meaning docs are not actually being generated using Markdown, or at least not Github Flavored Markdown.
