### PR TITLE
Don't open multiple build failure issues upon workflow cancellation

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -82,7 +82,7 @@ jobs:
           title: rubydoc.brew.sh deployment failed!
           body: The most recent [rubydoc.brew.sh deployment failed](${{ env.RUN_URL }}).
           labels: deploy failure
-          update-existing: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+          update-existing: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped') }}
           close-existing: ${{ needs.deploy.result == 'success' }}
           close-from-author: github-actions[bot]
           close-comment: The most recent [rubydoc.brew.sh deployment succeeded](${{ env.RUN_URL }}). Closing issue.


### PR DESCRIPTION
If the scheduled generation workflow fails, it opens an issue. If there are more failures, it adds additional comments to the same issue.

However, if a job is cancelled (either manually or if superseded by a new instance), a new issue is opened instead of commenting on the existing issue.

This is because the `Homebrew/actions/create-or-update-issue` action sets `update-existing` if there is a failed job. If the jobs are cancelled and there is no failure, then `update-existing` is false, meaning a new issue is opened.

Instead, set `update-existing` to true if any job has failed, was cancelled, or was skipped. That way, we will only get one issue at a time.

Once this is merged I'll test it out, and then if it works I'll open a PR in formulae.brew.sh